### PR TITLE
:bug: fix: Não acessando promoter pelo CNPJ

### DIFF
--- a/lib/promoter.ts
+++ b/lib/promoter.ts
@@ -28,8 +28,8 @@ export type Promoter = {
 };
 
 export type PromoterEdicao = {
-    cpfORcpnj: string
-    status: string,
+    cpf: string | null,
+    cnpj: string | null,
     data_nasc: Date,
     telefone: string,
     usuario: {
@@ -206,29 +206,52 @@ export async function novaEdicaoPromoter(promoter: PromoterEdicao, id: string) {
 		throw new usuarioNaoEncontrado("Promoter com essa identificação não existe")
 	}
     try {
-        
-        const promoterAtualizado = await prisma.promoter.update({
-            where: { cpf: id},
-            data: {
-                status: promoter.status,
-                data_nasc: promoter.data_nasc,
-                telefone: promoter.telefone,
-                usuario: {
-                    update: { nome: promoter.usuario.nome}
-                },
-                endereco: {
-                    update: {
-                        rua: promoter.endereco.rua,
-                        numero: promoter.endereco.numero,
-                        bairro: promoter.endereco.bairro,
-                        cidade: promoter.endereco.cidade,
-                        estado: promoter.endereco.estado,
-                        cep: promoter.endereco.cep,
-                        complemento: promoter.endereco.complemento,
+        if (id.length === 11){
+
+            const promoterAtualizado = await prisma.promoter.update({
+                where: { cpf: id},
+                data: {
+                    data_nasc: promoter.data_nasc,
+                    telefone: promoter.telefone,
+                    usuario: {
+                        update: { nome: promoter.usuario.nome}
+                    },
+                    endereco: {
+                        update: {
+                            rua: promoter.endereco.rua,
+                            numero: promoter.endereco.numero,
+                            bairro: promoter.endereco.bairro,
+                            cidade: promoter.endereco.cidade,
+                            estado: promoter.endereco.estado,
+                            cep: promoter.endereco.cep,
+                            complemento: promoter.endereco.complemento,
+                        }
                     }
                 }
-            }
-        })
+            })
+        } else if (id.length === 14){
+            const promoterAtualizado = await prisma.promoter.update({
+                where: { cnpj: id},
+                data: {
+                    data_nasc: promoter.data_nasc,
+                    telefone: promoter.telefone,
+                    usuario: {
+                        update: { nome: promoter.usuario.nome}
+                    },
+                    endereco: {
+                        update: {
+                            rua: promoter.endereco.rua,
+                            numero: promoter.endereco.numero,
+                            bairro: promoter.endereco.bairro,
+                            cidade: promoter.endereco.cidade,
+                            estado: promoter.endereco.estado,
+                            cep: promoter.endereco.cep,
+                            complemento: promoter.endereco.complemento,
+                        }
+                    }
+                }
+            })
+        }
     } catch (e) {
         console.error('Erro ao atualizar o promoter:', e);
         return null


### PR DESCRIPTION
A API para atualização do promoter só estava buscando um promoter pelo cpf, mas ele tambem pode ser buscado pelo cpnj, foi corrigido.